### PR TITLE
Fix: Crashes when set loglevel=MININFO in docker

### DIFF
--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -11,12 +11,13 @@ import sys
 
 PYTHON3 = '/usr/bin/python3'
 dbPath = os.path.join(os.sep, 'home', 'py-kms', 'db', 'pykms_database.db')
-log_level = os.getenv('LOGLEVEL', 'INFO')
-
+log_level_bootstrap = log_level = os.getenv('LOGLEVEL', 'INFO')
+if log_level_bootstrap == "MININFO":
+  log_level_bootstrap = "INFO"
 loggersrv = logging.getLogger('logsrv')
-loggersrv.setLevel(log_level)
+loggersrv.setLevel(log_level_bootstrap)
 streamhandler = logging.StreamHandler(sys.stdout)
-streamhandler.setLevel(log_level)
+streamhandler.setLevel(log_level_bootstrap)
 formatter = logging.Formatter(fmt = '\x1b[94m%(asctime)s %(levelname)-8s %(message)s',
                               datefmt = '%a, %d %b %Y %H:%M:%S',)
 streamhandler.setFormatter(formatter)

--- a/docker/start.py
+++ b/docker/start.py
@@ -23,7 +23,9 @@ argumentVariableMapping = {
 sqliteWebPath = '/home/sqlite_web/sqlite_web.py'
 enableSQLITE = os.path.isfile(sqliteWebPath) and os.environ.get('SQLITE', 'false').lower() == 'true'
 dbPath = os.path.join(os.sep, 'home', 'py-kms', 'db', 'pykms_database.db')
-log_level = os.getenv('LOGLEVEL', 'INFO')
+log_level_bootstrap = log_level = os.getenv('LOGLEVEL', 'INFO')
+if log_level_bootstrap == "MININFO":
+  log_level_bootstrap = "INFO"
 log_file = os.environ.get('LOGFILE', 'STDOUT')
 listen_ip = os.environ.get('IP', '0.0.0.0')
 listen_port = os.environ.get('PORT', '1688')
@@ -87,9 +89,9 @@ def start_kms():
 # Main
 if (__name__ == "__main__"):
   loggersrv = logging.getLogger('logsrv')
-  loggersrv.setLevel(log_level)
+  loggersrv.setLevel(log_level_bootstrap)
   streamhandler = logging.StreamHandler(sys.stdout)
-  streamhandler.setLevel(log_level)
+  streamhandler.setLevel(log_level_bootstrap)
   formatter = logging.Formatter(fmt='\x1b[94m%(asctime)s %(levelname)-8s %(message)s',
                                 datefmt='%a, %d %b %Y %H:%M:%S')
   streamhandler.setFormatter(formatter)


### PR DESCRIPTION
# Issue
The docker bootstrap script will set its own logging level based on env var `LOGLEVEL`, but it doesn't register the level `MININFO`. Which causes `MININFO` not working for docker image users.

# Reproduction
Start docker image via the following command (latest image):
```bash
docker run --name kms --rm -e LOGLEVEL=MININFO -e LOGFILE=STDOUT -e CLIENT_COUNT=50 -p 1688:1688/tcp ghcr.io/py-kms-organization/py-kms
```

The container will throw following error:
```
Traceback (most recent call last):
  File "/usr/bin/entrypoint.py", line 17, in <module>
    loggersrv.setLevel(log_level)
  File "/usr/lib/python3.9/logging/__init__.py", line 1421, in setLevel
    self.level = _checkLevel(level)
  File "/usr/lib/python3.9/logging/__init__.py", line 198, in _checkLevel
    raise ValueError("Unknown level: %r" % level)
ValueError: Unknown level: 'MININFO'
```

# Fix
There're multiple possible fixes, I'd like to add a simple check and set loglevel to `INFO` in bootstrap scripts when the environment variable is `MININFO`, which doesn't requires additional loglevel register or rewrite of bootstrap script 😄 