### PR TITLE
Fix docker healthcheck to netcat to actual IP

### DIFF
--- a/docker/docker-py3-kms-minimal/Dockerfile
+++ b/docker/docker-py3-kms-minimal/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /home/py-kms
 
 EXPOSE ${PORT}/tcp
 
-HEALTHCHECK --interval=5m --timeout=3s --start-period=10s --retries=4 CMD echo | nc -z localhost ${PORT} || exit 1
+HEALTHCHECK --interval=5m --timeout=3s --start-period=10s --retries=4 CMD echo | nc -z ${IP%% *} ${PORT} || exit 1
 
 ENTRYPOINT ["/usr/bin/python3", "-u","/usr/bin/entrypoint.py"]
 CMD ["/usr/bin/start.py"]

--- a/docker/docker-py3-kms/Dockerfile
+++ b/docker/docker-py3-kms/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /home/py-kms
 EXPOSE ${PORT}/tcp
 EXPOSE 8080
 
-HEALTHCHECK --interval=5m --timeout=3s --start-period=10s --retries=4 CMD echo | nc -z localhost ${PORT} || exit 1
+HEALTHCHECK --interval=5m --timeout=3s --start-period=10s --retries=4 CMD echo | nc -z ${IP%% *} ${PORT} || exit 1
 
 ENTRYPOINT [ "/usr/bin/python3","-u","/usr/bin/entrypoint.py" ]
 CMD ["/usr/bin/start.py"]


### PR DESCRIPTION
When i was doing #61, I also noticed healthcheck is broken if you run custom IP and not listening on all interfaces (specificaly on loopback). So this is fix for that.