### PR TITLE
Added warning about removal of Etrigan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ This version of _py-kms_ is for itself a fork of the original implementation by 
 	- Microsoft Office 2019 ( Volume License )
 	- Microsoft Office 2021 ( Volume License )
   - It's written in Python (tested with Python 3.10.1).
-  - Supports execution by `Docker`, `systemd`, `Upstart` and many more...
-  - Includes a GUI for simple managing.
-  - Uses `sqlite` for persistent data storage.
+  - Supports execution by `Docker`, `systemd` and many more...
+  - Uses `sqlite` for persistent data storage (with a simple web-based explorer).
 
 ## Documentation
 The wiki has been completly reworked and is now available on [readthedocs.com](https://py-kms.readthedocs.io/en/latest/). It should you provide all necessary information how to setup and to use _py-kms_ , all without clumping this readme. The documentation also houses more details about activation with _py-kms_ and how to get GVLK keys.
@@ -46,7 +45,6 @@ The wiki has been completly reworked and is now available on [readthedocs.com](h
 - To start the server, execute `python3 pykms_Server.py [IPADDRESS] [PORT]`, the default _IPADDRESS_ is `0.0.0.0` ( all interfaces ) and the default _PORT_ is `1688`. Note that both the address and port are optional. It's allowed to use IPv4 and IPv6 addresses. If you have a IPv6-capable dual-stack OS, a dual-stack socket is created when using a IPv6 address.
 - To start the server automatically using Docker, execute `docker run -d --name py-kms --restart always -p 1688:1688 ghcr.io/py-kms-organization/py-kms`.
 - To show the help pages type: `python3 pykms_Server.py -h` and `python3 pykms_Client.py -h`.
-- For launching _py-kms_ GUI make the file `pykms_Server.py` executable with `chmod +x /path/to/folder/py-kms/pykms_Server.py`, then simply run `pykms_Server.py` by double-clicking.
 
 ## License
    - _py-kms_ is [![Unlicense](https://img.shields.io/badge/license-unlicense-lightgray.svg)](https://github.com/SystemRage/py-kms/blob/master/LICENSE)

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -93,7 +93,7 @@ Check syntax with `sudo systemd-analyze verify py3-kms.service`, correct file pe
 start the daemon `sudo systemctl start py3-kms.service` and view its status `sudo systemctl status py3-kms.service`. Check if daemon is correctly running with `cat </path/to/your/log/files/folder>/pykms_logserver.log`. Finally a
 few generic commands useful for interact with your daemon [here](https://linoxide.com/linux-how-to/enable-disable-services-ubuntu-systemd-upstart/).
 
-### Etrigan
+### Etrigan (deprecated)
 You can run py-kms daemonized (via [Etrigan](https://github.com/SystemRage/Etrigan)) using a command like `python3 pykms_Server.py etrigan start` and stop it with `python3 pykms_Server.py etrigan stop`. With Etrigan you have another
 way to launch py-kms GUI (specially suitable if you're using a virtualenv), so `python3 pykms_Server.py etrigan start -g` and stop the GUI with `python3 pykms_Server.py etrigan stop` (or interact with the `EXIT` button).
 
@@ -168,7 +168,6 @@ They might be useful to you:
 
 ### Dependencies
 - Python 3.x.
-- Tkinter module (for the GUI).
 - If the `tzlocal` module is installed, the "Request Time" in the verbose output will be converted into local time. Otherwise, it will be in UTC.
 - It can use the `sqlite3` module, storing activation data in a database so it can be recalled again.
 - Installation example on Ubuntu / Mint:

--- a/py-kms/pykms_Server.py
+++ b/py-kms/pykms_Server.py
@@ -556,10 +556,13 @@ def server_main_terminal():
         else:
                 # (with or without GUI) and (with daemon)
                 # Setup daemon (eventually).
+                pretty_printer(log_obj = loggersrv.warning, put_text = "{reverse}{yellow}{bold}Etrigan support is deprecated and will be removed in the future!{end}")
                 server_daemon()
 
 def server_with_gui():
         import pykms_GuiBase
+
+        pretty_printer(log_obj = loggersrv.warning, put_text = "{reverse}{yellow}{bold}Etrigan GUI support is deprecated and will be removed in the future!{end}")
 
         root = pykms_GuiBase.KmsGui()
         root.title(pykms_GuiBase.gui_description + ' (' + pykms_GuiBase.gui_version + ')')

--- a/py-kms/pykms_Server.py
+++ b/py-kms/pykms_Server.py
@@ -208,7 +208,7 @@ The default is \"364F463A8863D35F\" or type \"RANDOM\" to auto generate the HWID
                         'def' : None, 'des' : "timeoutsndrcv"},
         'asyncmsg'   : {'help' : 'Prints pretty / logging messages asynchronously. Deactivated by default.',
                         'def' : False, 'des' : "asyncmsg"},
-        'llevel'     : {'help' : 'Use this option to set a log level. The default is \"ERROR\".', 'def' : "ERROR", 'des' : "loglevel",
+        'llevel'     : {'help' : 'Use this option to set a log level. The default is \"WARNING\".', 'def' : "WARNING", 'des' : "loglevel",
                         'choi' : ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "MININFO"]},
         'lfile'      : {'help' : 'Use this option to set an output log file. The default is \"pykms_logserver.log\". \
 Type \"STDOUT\" to view log info on stdout. Type \"FILESTDOUT\" to combine previous actions. \


### PR DESCRIPTION
This PR adds a warning about pending removal of Etrigan support.

### Why?
- Because Etrigan was not updated anymore since years - it works, but there is nobody to fix it if it breaks, so let's remove it now before it is too late.
- The Etrigan GUI is just some tkinter window. There is no real reason, why to limit it to Etrigan-only existence!
- Dropping GUI support will remove some boilerplate code from the client
- Dropping GUI code will remove MUCH code from the server + some libraries
- It gives us/me the ability to focus on developing a new web-based GUI, while the old is being stripped out at the same moment -> that will then solve the issue #75 

### Remaining steps
- [ ] Test on real hardware (both bare+Docker), just in case I made a typo :P