### PR TITLE
Use IPv6 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This version of _py-kms_ is for itself a fork of the original implementation by 
 The wiki has been completly reworked and is now available on [readthedocs.com](https://py-kms.readthedocs.io/en/latest/). It should you provide all necessary information how to setup and to use _py-kms_ , all without clumping this readme. The documentation also houses more details about activation with _py-kms_ and how to get GVLK keys.
        
 ## Quick start
-- To start the server, execute `python3 pykms_Server.py [IPADDRESS] [PORT]`, the default _IPADDRESS_ is `0.0.0.0` ( all interfaces ) and the default _PORT_ is `1688`. Note that both the address and port are optional. It's allowed to use IPv4 and IPv6 addresses. If you have a IPv6-capable dual-stack OS, a dual-stack socket is created when using a IPv6 address.
+- To start the server, execute `python3 pykms_Server.py [IPADDRESS] [PORT]`, the default _IPADDRESS_ is `::` ( all interfaces ) and the default _PORT_ is `1688`. Note that both the address and port are optional. It's allowed to use IPv4 and IPv6 addresses. If you have a IPv6-capable dual-stack OS, a dual-stack socket is created when using a IPv6 address. **In case your OS does not support IPv6, make sure to explicitly specify the legacy IPv4 of `0.0.0.0`!**
 - To start the server automatically using Docker, execute `docker run -d --name py-kms --restart always -p 1688:1688 ghcr.io/py-kms-organization/py-kms`.
 - To show the help pages type: `python3 pykms_Server.py -h` and `python3 pykms_Client.py -h`.
 - For launching _py-kms_ GUI make the file `pykms_Server.py` executable with `chmod +x /path/to/folder/py-kms/pykms_Server.py`, then simply run `pykms_Server.py` by double-clicking.

--- a/charts/py-kms/README.md
+++ b/charts/py-kms/README.md
@@ -44,7 +44,7 @@ For more information please refer to the Helm Install command documentation loca
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | py-kms.environment.HWID | string | `"RANDOM"` |  |
-| py-kms.environment.IP | string | `"0.0.0.0"` |  |
+| py-kms.environment.IP | string | `"::"` |  |
 | py-kms.environment.LOGLEVEL | string | `"INFO"` |  |
 | py-kms.environment.LOGSIZE | int | `2` |  |
 | py-kms.environment.SQLITE | bool | `true` |  |

--- a/charts/py-kms/values.yaml
+++ b/charts/py-kms/values.yaml
@@ -21,7 +21,7 @@ py-kms:
     LOGFILE: /var/log/py-kms.log
     HWID: RANDOM
     SQLITE: true
-    IP: 0.0.0.0
+    IP: '::'
 
 serviceAccount: {}
   # # Specifies whether a service account should be created

--- a/docker/docker-py3-kms-minimal/Dockerfile
+++ b/docker/docker-py3-kms-minimal/Dockerfile
@@ -1,7 +1,7 @@
 # This is a minimized version from docker/docker-py3-kms/Dockerfile without SQLite support to further reduce image size
 FROM alpine:3.15
 
-ENV IP 0.0.0.0
+ENV IP ::
 ENV PORT 1688
 ENV EPID ""
 ENV LCID 1033

--- a/docker/docker-py3-kms/Dockerfile
+++ b/docker/docker-py3-kms/Dockerfile
@@ -1,7 +1,7 @@
 # Switch to the target image
 FROM alpine:3.15
 
-ENV IP 0.0.0.0
+ENV IP ::
 ENV PORT 1688
 ENV EPID ""
 ENV LCID 1033

--- a/docker/start.py
+++ b/docker/start.py
@@ -27,7 +27,7 @@ log_level_bootstrap = log_level = os.environ.get('LOGLEVEL', 'INFO')
 if log_level_bootstrap == "MININFO":
   log_level_bootstrap = "INFO"
 log_file = os.environ.get('LOGFILE', 'STDOUT')
-listen_ip = os.environ.get('IP', '0.0.0.0').split()
+listen_ip = os.environ.get('IP', '::').split()
 listen_port = os.environ.get('PORT', '1688')
 sqlite_port = os.environ.get('SQLITE_PORT', '8080')
 

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -48,7 +48,7 @@ services:
       - 1688:1688
       - 8080:8080
     environment:
-      - IP=0.0.0.0
+      - IP='::'
       - SQLITE=true
       - HWID=RANDOM
       - LOGLEVEL=INFO
@@ -84,7 +84,7 @@ Restart=always
 RestartSec=1
 KillMode=process
 User=root
-ExecStart=/usr/bin/python3 </path/to/your/pykms/files/folder>/py-kms/pykms_Server.py 0.0.0.0 1688 -V DEBUG -F </path/to/your/log/files/folder>/pykms_logserver.log
+ExecStart=/usr/bin/python3 </path/to/your/pykms/files/folder>/py-kms/pykms_Server.py :: 1688 -V DEBUG -F </path/to/your/log/files/folder>/pykms_logserver.log
 
 [Install]
 WantedBy=multi-user.target
@@ -107,7 +107,7 @@ env PYKMSPATH=</path/to/your/pykms/files/folder>/py-kms
 env LOGPATH=</path/to/your/log/files/folder>/pykms_logserver.log
 start on runlevel [2345]
 stop on runlevel [016]
-exec $PYTHONPATH/python3 $PYKMSPATH/pykms_Server.py 0.0.0.0 1688 -V DEBUG -F $LOGPATH
+exec $PYTHONPATH/python3 $PYKMSPATH/pykms_Server.py :: 1688 -V DEBUG -F $LOGPATH
 respawn
 ```
 Check syntax with `sudo init-checkconf -d /etc/init/py3-kms.conf`, then reload upstart to recognise this process `sudo initctl reload-configuration`. Now start the service `sudo start py3-kms`, and you can see the logfile

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -7,7 +7,7 @@
 Follows a list of usable parameters:
 
     ip <IPADDRESS>
-> Instructs py-kms to listen on _IPADDRESS_ (can be an hostname too). If this option is not specified, _IPADDRESS_ 0.0.0.0 is used.
+> Instructs py-kms to listen on _IPADDRESS_ (can be an hostname too). If this option is not specified, _IPADDRESS_ `::` is used.
 
     port <PORT>
 > Define TCP _PORT_ the KMS service is listening on. Default is 1688.
@@ -75,7 +75,7 @@ user@host ~/path/to/folder/py-kms $ python3 pykms_Server.py -V INFO
 ```
 creates _pykms_logserver.log_ with these initial messages:
 ```
-Mon, 12 Jun 2017 22:09:00 INFO     TCP server listening at 0.0.0.0 on port 1688.
+Mon, 12 Jun 2017 22:09:00 INFO     TCP server listening at :: on port 1688.
 Mon, 12 Jun 2017 22:09:00 INFO     HWID: 364F463A8863D35F
 ```
 
@@ -125,14 +125,14 @@ examples (with fictitious addresses and ports):
 
 | command | address (main) | backlog (main) | reuse port (main) | address (listen) | backlog (listen) | reuse port (listen) | dualstack (main / listen) |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `python3 pykms_Server.py connect -b 12` | ('0.0.0.0', 1688) | 12 | True | [] | [] | [] | False |
+| `python3 pykms_Server.py connect -b 12` | ('::', 1688) | 12 | True | [] | [] | [] | False |
 | `python3 pykms_Server.py :: connect -b 12 -u -d` | ('::', 1688) | 12 | False | [] | [] | [] | True |
-| `python3 pykms_Server.py connect -n 1.1.1.1,1699 -b 10` | ('0.0.0.0', 1688) | 5 | True | [('1.1.1.1', 1699)] | [10] | [True] | False |
+| `python3 pykms_Server.py connect -n 1.1.1.1,1699 -b 10` | ('::', 1688) | 5 | True | [('1.1.1.1', 1699)] | [10] | [True] | False |
 | `python3 pykms_Server.py :: 1655 connect -n 2001:db8:0:200::7,1699 -d -b 10 -n 2.2.2.2,1677 -u` | ('::', 1655) | 5 | True | [('2001:db8:0:200::7', 1699), ('2.2.2.2', 1677)] | [10, 5] | [True, False] | True |
-| `python3 pykms_Server.py connect -b 12 -u -n 1.1.1.1,1699 -b 10 -n 2.2.2.2,1677 -b 15` | ('0.0.0.0', 1688) | 12 | False | [('1.1.1.1', 1699), ('2.2.2.2', 1677)] | [10, 15] | [False, False] | False |
-| `python3 pykms_Server.py connect -b 12 -n 1.1.1.1,1699 -u -n 2.2.2.2,1677` | ('0.0.0.0', 1688) | 12 | True | [('1.1.1.1', 1699), ('2.2.2.2', 1677)] | [12, 12] | [False, True] | False |
-| `python3 pykms_Server.py connect -d -u -b 8 -n 1.1.1.1,1699 -n 2.2.2.2,1677 -b 12` | ('0.0.0.0', 1688) | 8 | False | [('1.1.1.1', 1699), ('2.2.2.2', 1677)] | [8, 12] | [False, False] | True |
-| `python3 pykms_Server.py connect -b 11 -u -n ::,1699 -n 2.2.2.2,1677` | ('0.0.0.0', 1688) | 11 | False | [('::', 1699), ('2.2.2.2', 1677)] | [11, 11] | [False, False] | False |
+| `python3 pykms_Server.py connect -b 12 -u -n 1.1.1.1,1699 -b 10 -n 2.2.2.2,1677 -b 15` | ('::', 1688) | 12 | False | [('1.1.1.1', 1699), ('2.2.2.2', 1677)] | [10, 15] | [False, False] | False |
+| `python3 pykms_Server.py connect -b 12 -n 1.1.1.1,1699 -u -n 2.2.2.2,1677` | ('::', 1688) | 12 | True | [('1.1.1.1', 1699), ('2.2.2.2', 1677)] | [12, 12] | [False, True] | False |
+| `python3 pykms_Server.py connect -d -u -b 8 -n 1.1.1.1,1699 -n 2.2.2.2,1677 -b 12` | ('::', 1688) | 8 | False | [('1.1.1.1', 1699), ('2.2.2.2', 1677)] | [8, 12] | [False, False] | True |
+| `python3 pykms_Server.py connect -b 11 -u -n ::,1699 -n 2.2.2.2,1677` | ('::', 1688) | 11 | False | [('::', 1699), ('2.2.2.2', 1677)] | [11, 11] | [False, False] | False |
 
 ### pykms_Client.py
 If _py-kms_ server doesn't works correctly, you can test it with the KMS client `pykms_Client.py`, running on the same machine where you started `pykms_Server.py`.
@@ -202,8 +202,8 @@ You can enable same _pykms_Server.py_ suboptions of `-F`.
 This are the currently used `ENV` statements from the Dockerfile(s). For further references what exactly the parameters mean, please see the start parameters for the [server](Usage.html#pykms-server-py).
 ```
 # IP-address
-# The IP address to listen on. The default is "0.0.0.0" (all interfaces).
-ENV IP 0.0.0.0
+# The IP address to listen on. The default is "::" (all interfaces).
+ENV IP ::
 
 # TCP-port
 # The network port to listen on. The default is "1688".

--- a/py-kms/pykms_Client.py
+++ b/py-kms/pykms_Client.py
@@ -56,7 +56,7 @@ loggerclt = logging.getLogger('logclt')
 
 # 'help' string - 'default' value - 'dest' string.
 clt_options = {
-        'ip'       : {'help' : 'The IP address or hostname of the KMS server.', 'def' : "0.0.0.0", 'des' : "ip"},
+        'ip'       : {'help' : 'The IP address or hostname of the KMS server.', 'def' : "::", 'des' : "ip"},
         'port'     : {'help' : 'The port the KMS service is listening on. The default is \"1688\".', 'def' : 1688, 'des' : "port"},
         'mode'     : {'help' : 'Use this flag to manually specify a Microsoft product for testing the server. The default is \"Windows81\"',
                       'def' : "Windows8.1", 'des' : "mode",

--- a/py-kms/pykms_Server.py
+++ b/py-kms/pykms_Server.py
@@ -220,7 +220,7 @@ Use \"STDOUTOFF\" to disable stdout messages. Use \"FILEOFF\" if you not want to
         'reuse'      : {'help' : 'Do not allows binding / listening to the same address and port. Reusing port is activated by default.', 'def' : True,
                         'des': "reuse"},
         'dual'       : {'help' : 'Allows listening to an IPv6 address also accepting connections via IPv4. Deactivated by default.',
-                        'def' : False, 'des': "dual"}
+                        'def' : True, 'des': "dual"}
         }
 
 def server_options():

--- a/py-kms/pykms_Server.py
+++ b/py-kms/pykms_Server.py
@@ -184,7 +184,7 @@ loggersrv = logging.getLogger('logsrv')
 
 # 'help' string - 'default' value - 'dest' string.
 srv_options = {
-        'ip'         : {'help' : 'The IP address (IPv4 or IPv6) to listen on. The default is \"0.0.0.0\" (all interfaces).', 'def' : "0.0.0.0", 'des' : "ip"},
+        'ip'         : {'help' : 'The IP address (IPv4 or IPv6) to listen on. The default is \"::\" (all interfaces).', 'def' : "::", 'des' : "ip"},
         'port'       : {'help' : 'The network port to listen on. The default is \"1688\".', 'def' : 1688, 'des' : "port"},
         'epid'       : {'help' : 'Use this option to manually specify an ePID to use. If no ePID is specified, a random ePID will be auto generated.',
                         'def' : None, 'des' : "epid"},


### PR DESCRIPTION
This will listen to IPv6 by default, as well as create dual-stack sockets by default.

Linux Kernels, which have IPv6 removed / disabled won't be able to start the `py-kms` server anymore, without explicitly changing the `listen_addr` as well as the `dual`-parameter.

Closes #71 

### Remaining steps
- [ ] Test on real IPv6-hardware (both bare+Docker)