### PR TITLE
Semantic version

### DIFF
--- a/.github/workflows/bake_to_latest.yml
+++ b/.github/workflows/bake_to_latest.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   bake-latest:

--- a/.github/workflows/bake_to_latest.yml
+++ b/.github/workflows/bake_to_latest.yml
@@ -14,20 +14,20 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-      - name: Set up QEMU
+        uses: actions/checkout@v6
+      - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - name: Set up Docker Buildx
+      - name: Docker Setup Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/bake_to_next.yml
+++ b/.github/workflows/bake_to_next.yml
@@ -14,20 +14,20 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-      - name: Set up QEMU
+        uses: actions/checkout@v6
+      - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - name: Set up Docker Buildx
+      - name: Docker Setup Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/bake_to_next.yml
+++ b/.github/workflows/bake_to_next.yml
@@ -1,4 +1,4 @@
-name: Build next-tags
+name: Build next tags
 
 on:
   workflow_dispatch:
@@ -39,10 +39,17 @@ jobs:
           file: ./docker/docker-py3-kms/Dockerfile
           platforms: linux/amd64,linux/386,linux/arm64/v8,linux/arm/v7,linux/arm/v6
           push: true
-          tags: pykmsorg/py-kms:python3-next,ghcr.io/py-kms-organization/py-kms:python3-next
+          # the tag "python3-next" is for backward compatibility only
+          tags: |
+            pykmsorg/py-kms:next
+            ghcr.io/py-kms-organization/py-kms:next
+            pykmsorg/py-kms:next-full
+            ghcr.io/py-kms-organization/py-kms:next-full
+            pykmsorg/py-kms:python3-next
+            ghcr.io/py-kms-organization/py-kms:python3-next
           build-args: |
             BUILD_COMMIT=${{ github.sha }}
-            BUILD_BRANCH=${{ github.ref_name }}
+            BUILD_REFERENCE=${{ github.ref_name }}
       - name: Build (minimal)
         uses: docker/build-push-action@v6
         with:
@@ -50,7 +57,14 @@ jobs:
           file: ./docker/docker-py3-kms-minimal/Dockerfile
           platforms: linux/amd64,linux/386,linux/arm64/v8,linux/arm/v7,linux/arm/v6
           push: true
-          tags: pykmsorg/py-kms:latest-next,ghcr.io/py-kms-organization/py-kms:latest-next,pykmsorg/py-kms:minimal-next,ghcr.io/py-kms-organization/py-kms:minimal-next
+          # the tag "latest-next" and "minimal-next" are for backward compatibility only
+          tags: |
+            pykmsorg/py-kms:next-minimal
+            ghcr.io/py-kms-organization/py-kms:next-minimal
+            pykmsorg/py-kms:latest-next
+            ghcr.io/py-kms-organization/py-kms:latest-next
+            pykmsorg/py-kms:minimal-next
+            ghcr.io/py-kms-organization/py-kms:minimal-next
           build-args: |
             BUILD_COMMIT=${{ github.sha }}
-            BUILD_BRANCH=${{ github.ref_name }}
+            BUILD_REFERENCE=${{ github.ref_name }}

--- a/.github/workflows/bake_to_test.yml
+++ b/.github/workflows/bake_to_test.yml
@@ -25,7 +25,7 @@ jobs:
           push: false
           build-args: |
             BUILD_COMMIT=${{ github.sha }}
-            BUILD_BRANCH=${{ github.ref_name }}
+            BUILD_REFERENCE=${{ github.ref_name }}
       - name: Build (minimal)
         uses: docker/build-push-action@v6
         with:
@@ -35,4 +35,4 @@ jobs:
           push: false
           build-args: |
             BUILD_COMMIT=${{ github.sha }}
-            BUILD_BRANCH=${{ github.ref_name }}
+            BUILD_REFERENCE=${{ github.ref_name }}

--- a/.github/workflows/bake_to_test.yml
+++ b/.github/workflows/bake_to_test.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-      - name: Set up QEMU
+        uses: actions/checkout@v6
+      - name: Docker Setup QEMU
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - name: Set up Docker Buildx
+      - name: Docker Setup Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build (full)
         uses: docker/build-push-action@v6

--- a/.github/workflows/bake_to_version.yml
+++ b/.github/workflows/bake_to_version.yml
@@ -1,10 +1,10 @@
-name: Build latest/main tags
+name: Build version tags
 
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 jobs:
   bake-latest:
@@ -39,14 +39,9 @@ jobs:
           file: ./docker/docker-py3-kms/Dockerfile
           platforms: linux/amd64,linux/386,linux/arm64/v8,linux/arm/v7,linux/arm/v6
           push: true
-          # the tag "python3" is for backward compatibility only
           tags: |
-            pykmsorg/py-kms:main
-            ghcr.io/py-kms-organization/py-kms:main
-            pykmsorg/py-kms:main-full
-            ghcr.io/py-kms-organization/py-kms:main-full
-            pykmsorg/py-kms:python3
-            ghcr.io/py-kms-organization/py-kms:python3
+            pykmsorg/py-kms:${{ github.ref_name }}-full
+            ghcr.io/py-kms-organization/py-kms:${{ github.ref_name }}-full
           build-args: |
             BUILD_COMMIT=${{ github.sha }}
             BUILD_REFERENCE=${{ github.ref_name }}
@@ -57,14 +52,11 @@ jobs:
           file: ./docker/docker-py3-kms-minimal/Dockerfile
           platforms: linux/amd64,linux/386,linux/arm64/v8,linux/arm/v7,linux/arm/v6
           push: true
-          # the tag "minimal" is for backward compatibility only
           tags: |
-            pykmsorg/py-kms:latest
-            ghcr.io/py-kms-organization/py-kms:latest
-            pykmsorg/py-kms:main-minimal
-            ghcr.io/py-kms-organization/py-kms:main-minimal
-            pykmsorg/py-kms:minimal
-            ghcr.io/py-kms-organization/py-kms:minimal
+            pykmsorg/py-kms:${{ github.ref_name }}
+            ghcr.io/py-kms-organization/py-kms:${{ github.ref_name }}
+            pykmsorg/py-kms:${{ github.ref_name }}-minimal
+            ghcr.io/py-kms-organization/py-kms:${{ github.ref_name }}-minimal
           build-args: |
             BUILD_COMMIT=${{ github.sha }}
             BUILD_REFERENCE=${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# Readme
+# py-kms
+
 ![repo-size](https://img.shields.io/github/repo-size/Py-KMS-Organization/py-kms)
 ![open-issues](https://img.shields.io/github/issues/Py-KMS-Organization/py-kms)
 ![last-commit](https://img.shields.io/github/last-commit/Py-KMS-Organization/py-kms/master)
 ![docker-pulls](https://img.shields.io/docker/pulls/pykmsorg/py-kms)
 ![read-the-docs](https://img.shields.io/readthedocs/py-kms)
-***
 
 _Keep in mind that this project is not intended for production use. Feel free to use it to test your own systems or maybe even learn something from the protocol structure._ 😉
 
 ## History
 _py-kms_ is a port of node-kms created by [cyrozap](http://forums.mydigitallife.info/members/183074-markedsword), which is a port of either the C#, C++, or .NET implementations of KMS Emulator. The original version was written by [CODYQX4](http://forums.mydigitallife.info/members/89933-CODYQX4) and is derived from the reverse-engineered code of Microsoft's official KMS.
 This version of _py-kms_ is for itself a fork of the original implementation by [SystemRage](https://github.com/SystemRage/py-kms), which was abandoned early 2021.
+
+### What is with version `1.0.0`?
+Semantic versioning is now being used in this project, so checkout the [GitHub Releases](https://github.com/Py-KMS-Organization/py-kms/releases). Before, a `CHANGELOG.md` file was used to track changes, but got abandoned over time. Its content got moved into the [Historic Releases](docs/Historic%20Releases.md) document for reference. 
 
 ## Features
 - Responds to `v4`, `v5`, and `v6` KMS requests.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![repo-size](https://img.shields.io/github/repo-size/Py-KMS-Organization/py-kms)
 ![open-issues](https://img.shields.io/github/issues/Py-KMS-Organization/py-kms)
-![last-commit](https://img.shields.io/github/last-commit/Py-KMS-Organization/py-kms/master)
+![last-commit](https://img.shields.io/github/last-commit/Py-KMS-Organization/py-kms/main)
 ![docker-pulls](https://img.shields.io/docker/pulls/pykmsorg/py-kms)
 ![read-the-docs](https://img.shields.io/readthedocs/py-kms)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![read-the-docs](https://img.shields.io/readthedocs/py-kms)
 ***
 
-_Keep in mind that this project is not intended for production use. Feel free to use it to test your own systems or maybe even learn something from the protocol structure. :)_
+_Keep in mind that this project is not intended for production use. Feel free to use it to test your own systems or maybe even learn something from the protocol structure._ 😉
 
 ## History
 _py-kms_ is a port of node-kms created by [cyrozap](http://forums.mydigitallife.info/members/183074-markedsword), which is a port of either the C#, C++, or .NET implementations of KMS Emulator. The original version was written by [CODYQX4](http://forums.mydigitallife.info/members/89933-CODYQX4) and is derived from the reverse-engineered code of Microsoft's official KMS.
@@ -14,35 +14,20 @@ This version of _py-kms_ is for itself a fork of the original implementation by 
 
 ## Features
 - Responds to `v4`, `v5`, and `v6` KMS requests.
-- Supports activating:
-	- Windows Vista 
-	- Windows 7 
-	- Windows 8
-	- Windows 8.1
-	- Windows 10 ( 1511 / 1607 / 1703 / 1709 / 1803 / 1809 )
-    - Windows 10 ( 1903 / 1909 / 20H1, 20H2, 21H1, 21H2 )
-    - Windows 11 ( 21H2 )
-	- Windows Server 2008
-	- Windows Server 2008 R2
-	- Windows Server 2012
-	- Windows Server 2012 R2
-	- Windows Server 2016
-	- Windows Server 2019
-	- Windows Server 2022
-	- Microsoft Office 2010 ( Volume License )
-	- Microsoft Office 2013 ( Volume License )
-	- Microsoft Office 2016 ( Volume License )
-	- Microsoft Office 2019 ( Volume License )
-	- Microsoft Office 2021 ( Volume License )
-  - It's written in Python (tested with Python 3.10.1).
+- Supports activating [a lot of products](docs/Keys.md), so checkout the docs for more information.
+  - It's written in Python.
   - Supports execution by `Docker`, `systemd` and many more...
   - Uses `sqlite` for persistent data storage (with a simple web-based explorer).
 
 ## Documentation
-The wiki has been completly reworked and is now available on [readthedocs.io](https://py-kms.readthedocs.io/en/latest/). It should provide you all the necessary information about how to setup and to use _py-kms_ , all without clumping this readme. The documentation also houses more details about activation with _py-kms_ and how to get GVLK keys.
+The wiki has been completly reworked and is now available on [readthedocs.io](https://py-kms.readthedocs.io/en/latest/). It should provide you all the necessary information about how to setup and to use _py-kms_, all without clumping this readme. The documentation also houses more details about the activation procedure with _py-kms_ and how to get GVLK keys.
        
 ## Quick start
-- To start the server, execute `python3 pykms_Server.py [IPADDRESS] [PORT]`, the default _IPADDRESS_ is `::` ( all interfaces ) and the default _PORT_ is `1688`. Note that both the address and port are optional. It's allowed to use IPv4 and IPv6 addresses. If you have a IPv6-capable dual-stack OS, a dual-stack socket is created when using a IPv6 address. **In case your OS does not support IPv6, make sure to explicitly specify the legacy IPv4 of `0.0.0.0`!**
+- To start the server, execute `python3 pykms_Server.py [IPADDRESS] [PORT]`, the default _IPADDRESS_ is `::` ( all interfaces ) and the default _PORT_ is `1688`.
+	- Note that both the address and port are optional.
+	- It's allowed to use IPv4 and IPv6 addresses.
+	- If you have an IPv6-capable dual-stack OS, a dual-stack socket is created when using a IPv6 address.
+	- **[In case your OS does not support IPv6](https://github.com/Py-KMS-Organization/py-kms/issues/108), make sure to explicitly specify the legacy IPv4 of `0.0.0.0`!**
 - To start the server automatically using Docker, execute `docker run -d --name py-kms --restart always -p 1688:1688 ghcr.io/py-kms-organization/py-kms`.
 - To show the help pages type: `python3 pykms_Server.py -h` and `python3 pykms_Client.py -h`.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Semantic versioning is now being used in this project, so checkout the [GitHub R
   - Uses `sqlite` for persistent data storage (with a simple web-based explorer).
 
 ## Documentation
-The wiki has been completly reworked and is now available on [readthedocs.io](https://py-kms.readthedocs.io/en/latest/). It should provide you all the necessary information about how to setup and to use _py-kms_, all without clumping this readme. The documentation also houses more details about the activation procedure with _py-kms_ and how to get GVLK keys.
+The wiki has been completely reworked and is now available on [readthedocs.io](https://py-kms.readthedocs.io/en/latest/). It should provide you all the necessary information about how to setup and to use _py-kms_, all without clumping this readme. The documentation also houses more details about the activation procedure with _py-kms_ and how to get GVLK keys.
        
 ## Quick start
 - To start the server, execute `python3 pykms_Server.py [IPADDRESS] [PORT]`, the default _IPADDRESS_ is `::` ( all interfaces ) and the default _PORT_ is `1688`.

--- a/docker/docker-py3-kms/Dockerfile
+++ b/docker/docker-py3-kms/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:3.22
 
 ARG BUILD_COMMIT=unknown
-ARG BUILD_BRANCH=unknown
+ARG BUILD_REFERENCE=unknown
 
 ENV IP=::
 ENV DUALSTACK=1
@@ -50,7 +50,7 @@ RUN chown root: -R /home/py-kms && \
 
 # Web-interface specifics
 COPY LICENSE /LICENSE
-RUN echo "$BUILD_COMMIT" > /VERSION && echo "$BUILD_BRANCH" >> /VERSION
+RUN echo "$BUILD_COMMIT" > /VERSION && echo "$BUILD_REFERENCE" >> /VERSION
 
 WORKDIR /home/py-kms
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -3,7 +3,7 @@
 You want to improve this project? 
 Awesome! But before you write or modify the existing source code, please note the following guideline:
 
-- Always make sure to add your changes to the wiki.
+- Always base your branch on the latest `next` branch to avoid merge conflicts.
 - 8-space indentation without tabs.
 - Docstrings as this:
 ```python

--- a/docs/Historic Releases.md
+++ b/docs/Historic Releases.md
@@ -1,5 +1,7 @@
 # Changelog
 
+**THIS IS A HISTORIC RELEASES FILE.** Nowadays we moved to proper semantic versioning and use Git-based tagging to track releases instead.
+
 ## py-kms_2022-12-16
 - Added support for new web-gui into Docker
 - Implemented whole-new web-based GUI with Flask

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,1 +1,0 @@
-../CHANGELOG.md

--- a/py-kms/pykms_WebUI.py
+++ b/py-kms/pykms_WebUI.py
@@ -55,7 +55,7 @@ if os.path.exists(_version_info_path):
     with open(_version_info_path, 'r') as f:
         app.jinja_env.globals['version_info'] = {
             'hash': f.readline().strip(),
-            'branch': f.readline().strip()
+            'reference': f.readline().strip()
         }
 
 _dbEnvVarName = 'PYKMS_SQLITE_DB_PATH'

--- a/py-kms/templates/base.html
+++ b/py-kms/templates/base.html
@@ -41,7 +41,7 @@
                 <strong>py-kms</strong> is online since <span class="convert_timestamp">{{ start_time }}</span>.
                 This instance was accessed {{ get_serve_count() }} times. View this softwares license <a href="/license">here</a>.
                 {% if version_info %}
-                <br>This instance is running version "{{ version_info['hash'] }}" from branch "{{ version_info['branch'] }}" of py-kms.
+                <br>This instance is running version "{{ version_info['hash'] }}" from Git "{{ version_info['reference'] }}" of py-kms.
                 {% endif %}
             </p>
         </div>


### PR DESCRIPTION
Closes #116 

...the reset of this we have to do at the next release:

- [ ] switch default branch to `main`
- [ ] tag the next release as `v1.0.0` and create a GitHub release from it (this will then auto-trigger a workflow for a tagged Docker image being built)