### PR TITLE
fix: windows server 2019 activation failing because of incomplete entry in KmsDataBase.xml

### DIFF
--- a/py-kms/pykms_PidGenerator.py
+++ b/py-kms/pykms_PidGenerator.py
@@ -27,6 +27,9 @@ def epidGenerator(kmsId, version, lcid):
                 except IndexError:
                         # fallback to Windows Server 2019 parameters.
                         pkeys.append( ('206', '551000000', '570999999', '[0,1,2]') )   
+                except KeyError:
+                        # ignore malformed/incomplete entries
+                        pass
                                 
         pkey = random.choice(pkeys)
         GroupId, MinKeyId, MaxKeyId, Invalid = int(pkey[0]), int(pkey[1]), int(pkey[2]), literal_eval(pkey[3])


### PR DESCRIPTION
This fixes issue https://github.com/Py-KMS-Organization/py-kms/issues/138, where Windows Server 2019 would not work because of an entry in KmsDataBase.xml.

The entry for Windows Server 2019 (Azure Only) is missing MinKeyId and MaxKeyId which are required for pykms to compute the pid.

```xml
		<CsvlkItem DisplayName="Windows Server 2019 (Azure Only)" ReleaseDate="2018-10-02T00:00:00Z" GroupId="206" IniFileName="Windows" Id="3c006fa7-3b03-45a4-93da-63ddc1bdce11">
			<Activate KmsItem="8449b1fb-f0ea-497a-99ab-66ca96e9a0f5" />
			<Activate KmsItem="cbdcb1ba-e093-4c81-a463-10775291fdf9" />
		</CsvlkItem>
```

What this PR does is ignoring any invalid entries in the XML file, preventing the pid_generator from not returning when other valid entries exists.