### PR TITLE
Added feature: exposing prometheus metrics

### DIFF
--- a/docker/docker-py3-kms/requirements.txt
+++ b/docker/docker-py3-kms/requirements.txt
@@ -3,3 +3,4 @@ tzlocal==5.3.1
 
 Flask==3.1.2
 gunicorn==23.0.0
+prometheus-client==0.21.0

--- a/docker/start.py
+++ b/docker/start.py
@@ -27,6 +27,16 @@ listen_port = os.environ.get('PORT', '1688')
 want_webui = os.environ.get('WEBUI', '0') == '1' # if the variable is not provided, we assume the user does not want the webui
 
 def start_kms(logger):
+  # Set up Prometheus multiprocess directory for both KMS Server and WebUI
+  # This must be done BEFORE starting any process that writes metrics
+  prometheus_multiproc_dir = '/tmp/prometheus_multiproc'
+  if not os.path.exists(prometheus_multiproc_dir):
+    os.makedirs(prometheus_multiproc_dir, exist_ok=True)
+  # Set environment variables for this process and all child processes
+  os.environ['PROMETHEUS_MULTIPROC_DIR'] = prometheus_multiproc_dir
+  os.environ['prometheus_multiproc_dir'] = prometheus_multiproc_dir
+  logger.info(f"Prometheus multiprocess directory: {prometheus_multiproc_dir}")
+  
   # Make sure the full path to the db exists
   if want_webui and not os.path.exists(os.path.dirname(db_path)):
     os.makedirs(os.path.dirname(db_path), exist_ok=True)
@@ -61,7 +71,15 @@ def start_kms(logger):
       pykms_webui_env['PORT'] = '8080'
       pykms_webui_env['PYKMS_LICENSE_PATH'] = '/LICENSE'
       pykms_webui_env['PYKMS_VERSION_PATH'] = '/VERSION'
-      pykms_webui_process = subprocess.Popen(['gunicorn', '--log-level', os.environ.get('LOGLEVEL'), 'pykms_WebUI:app'], env=pykms_webui_env)
+      # Set up Prometheus multiprocess mode (for Gunicorn workers)
+      prometheus_multiproc_dir = '/tmp/prometheus_multiproc'
+      if not os.path.exists(prometheus_multiproc_dir):
+        os.makedirs(prometheus_multiproc_dir, exist_ok=True)
+      # Set both uppercase and lowercase variants for compatibility with different prometheus_client versions
+      pykms_webui_env['PROMETHEUS_MULTIPROC_DIR'] = prometheus_multiproc_dir
+      pykms_webui_env['prometheus_multiproc_dir'] = prometheus_multiproc_dir
+
+      pykms_webui_process = subprocess.Popen(['gunicorn', '--config', 'gunicorn_config.py', 'pykms_WebUI:app'], env=pykms_webui_env)
   except Exception as e:
     logger.error("Failed to start webui (ignoring and continuing anyways): %s" % e)
 

--- a/docs/Metrics.md
+++ b/docs/Metrics.md
@@ -1,0 +1,260 @@
+# Prometheus Metrics Documentation
+
+## Overview
+
+py-kms server (python3 Docker image only) supports exporting metrics in Prometheus format for monitoring and observability. This feature is designed for testing, learning, and lab environments to better understand KMS activation protocol behavior.
+
+## Availability
+
+**Metrics are available ONLY in the `python3` Docker image**, not in the `minimal` image.
+
+- **python3 image**: Includes Flask, Gunicorn, SQLite, and metrics support
+- **minimal image**: Lightweight, no WebUI or metrics
+
+## Configuration
+
+### Enabling/Disabling Metrics
+
+Metrics are **enabled by default** in the python3 image. To disable set METRICS environment variable to 0:
+
+```bash
+docker run -e METRICS=0 pykmsorg/py-kms:python3
+```
+
+### SKU Detail Level
+
+Control the level of SKU (Stock Keeping Unit) detail in activation counter metrics using the `METRICS_SKU_DETAIL` environment variable:
+
+- **`NONE`** (default): No SKU label, lowest cardinality
+- **`CATEGORY`**: SKU category (e.g., `windows-10`, `office-2019`, `windows-server-2022`)
+- **`DETAILED`**: Full SKU name (e.g., `Windows 10 Professional`, `Office 2019 ProPlus`)
+
+```bash
+# Default: no SKU label
+docker run pykmsorg/py-kms:python3
+
+# Category level (low cardinality)
+docker run -e METRICS_SKU_DETAIL=CATEGORY pykmsorg/py-kms:python3
+
+# Detailed level (may increase cardinality)
+docker run -e METRICS_SKU_DETAIL=DETAILED pykmsorg/py-kms:python3
+```
+
+### Duration Histogram Labels
+
+Control labels on the duration histogram metric to manage cardinality using the `METRICS_DURATION_LABELS` environment variable:
+
+- **`BASIC`** (default): Only `product` label (~51 time series: 3 products × 17 buckets)
+- **`EXTENDED`**: Add `product` and `kms_version` labels (~204 time series: 3 × 4 × 17)
+- **`DETAILED`**: Add `product`, `kms_version`, and `sku` labels (requires `METRICS_SKU_DETAIL` to be enabled, high cardinality)
+
+```bash
+# Default: BASIC (product label only)
+docker run pykmsorg/py-kms:python3
+
+# EXTENDED: if you need to track performance by product and KMS version
+docker run -e METRICS_DURATION_LABELS=EXTENDED pykmsorg/py-kms:python3
+
+# DETAILED: for per-SKU performance analysis (requires METRICS_SKU_DETAIL)
+docker run -e METRICS_SKU_DETAIL=CATEGORY -e METRICS_DURATION_LABELS=DETAILED pykmsorg/py-kms:python3
+```
+
+**Recommendation**: For most use cases, `BASIC` (default) is sufficient as it provides product-level breakdown with minimal cardinality impact. Use `EXTENDED` if you need to compare performance between KMS protocol versions, and `DETAILED` only for deep SKU-level analysis.
+
+**Cardinality Impact**:
+
+- `BASIC`: ~51 time series (3 products × 17 buckets/counters)
+- `EXTENDED`: ~204 time series (3 products × 4 versions × 17)
+- `DETAILED` with CATEGORY: ~3,000+ time series (depends on SKU count)
+
+### Accessing Metrics
+
+Metrics are exposed on the same port as the WebUI (default: 8080):
+
+[http://localhost:8080/metrics](http://localhost:8080/metrics)
+
+## Available Metrics
+
+### Service Information Metrics
+
+#### `pykms_up{version="..."}`
+
+- **Type**: Gauge
+- **Description**: Service availability (1 = up, 0 = down)
+- **Labels**: `version` - py-kms version string
+
+#### `pykms_start_time_seconds`
+
+- **Type**: Gauge
+- **Description**: Unix timestamp when the service started
+
+#### `pykms_info{version="...", python_version="..."}`
+
+- **Type**: Info
+- **Description**: Service information including versions
+
+### Request Metrics
+
+#### `pykms_activation_requests_total{status, product, kms_version [, sku]}`
+
+- **Type**: Counter
+- **Description**: Total number of KMS activation requests
+- **Labels**:
+  - `status`: `success` or `failure`
+  - `product`: `windows`, `office`, or `unknown`
+  - `kms_version`: `v4`, `v5`, `v6`, or `unknown`
+  - `sku` (optional): SKU information, included only if `METRICS_SKU_DETAIL` is not `NONE`
+    - When `CATEGORY`: e.g., `windows-10`, `office-2019`, `windows-server-2022`
+    - When `DETAILED`: e.g., `Windows 10 Professional`, `Office 2019 ProPlus`
+
+#### `pykms_activation_request_duration_seconds{product [, kms_version [, sku]]}`
+
+- **Type**: Histogram
+- **Description**: Time spent processing activation requests
+- **Labels** (configurable via `METRICS_DURATION_LABELS`):
+  - `BASIC` (default): `product` only
+  - `EXTENDED`: `product`, `kms_version`
+  - `DETAILED`: `product`, `kms_version`, `sku` (requires `METRICS_SKU_DETAIL` enabled)
+- **Buckets**: 0.001 to 10.0 seconds
+
+#### `pykms_active_connections`
+
+- **Type**: Gauge
+- **Description**: Current number of active TCP connections to KMS server
+
+#### `pykms_activations_last_30s{status, product}`
+
+- **Type**: Gauge
+- **Description**: Number of activation requests in the last 30 seconds
+- **Labels**:
+  - `status`: `success` or `failure`
+  - `product`: `windows`, `office`, or `unknown`
+- **Use Case**: Useful for low-traffic environments where `pykms_active_connections` is usually 0 due to short-lived connections
+
+#### `pykms_activations_last_60s{status, product}`
+
+- **Type**: Gauge
+- **Description**: Number of activation requests in the last 60 seconds (1 minute)
+- **Labels**:
+  - `status`: `success` or `failure`
+  - `product`: `windows`, `office`, or `unknown`
+- **Use Case**: Shows recent activation activity even when Prometheus scrape interval might miss short connections
+
+#### `pykms_activations_last_300s{status, product}`
+
+- **Type**: Gauge
+- **Description**: Number of activation requests in the last 300 seconds (5 minutes)
+- **Labels**:
+  - `status`: `success` or `failure`
+  - `product`: `windows`, `office`, or `unknown`
+- **Use Case**: Provides a longer window view of activation activity
+
+### Client Metrics
+
+#### `pykms_clients_total{application}`
+
+- **Type**: Gauge
+- **Description**: Total unique clients in database
+- **Labels**: `application` - `windows` or `office`
+
+#### `pykms_database_last_activation_by_application{application}`
+
+- **Type**: Gauge
+- **Description**: Unix timestamp of most recent activation by application type
+- **Labels**: `application` - `windows` or `office`
+- **Note**: Avoids high cardinality by not tracking individual clients
+
+### Database Metrics
+
+#### `pykms_database_size_bytes`
+
+- **Type**: Gauge
+- **Description**: Size of SQLite database file in bytes
+
+#### `pykms_database_last_activation_timestamp`
+
+- **Type**: Gauge
+- **Description**: Unix timestamp of most recent activation
+
+#### `pykms_database_total_requests`
+
+- **Type**: Gauge
+- **Description**: Sum of all request counts from all clients
+
+## Example Queries
+
+### Service Health
+
+```promql
+# Service uptime in hours
+(time() - pykms_start_time_seconds) / 3600
+```
+
+### Activation Analysis
+
+```promql
+# Activation requests per minute
+rate(pykms_activation_requests_total[5m]) * 60
+
+# Failed vs successful ratio
+rate(pykms_activation_requests_total{status="failure"}[5m]) / rate(pykms_activation_requests_total[5m])
+
+# Breakdown by product type
+sum by (product) (rate(pykms_activation_requests_total[5m]))
+
+# Breakdown by SKU category (when METRICS_SKU_DETAIL=CATEGORY)
+sum by (sku) (rate(pykms_activation_requests_total[5m]))
+
+# Windows 10 and Windows 11 activations (with CATEGORY level)
+sum by (sku) (rate(pykms_activation_requests_total{product="windows"}[5m]))
+
+# Office versions breakdown (with CATEGORY level)
+sum by (sku) (rate(pykms_activation_requests_total{product="office"}[5m]))
+```
+
+### Performance Monitoring
+
+```promql
+# Overall P95 latency (works with all METRICS_DURATION_LABELS levels)
+histogram_quantile(0.95, rate(pykms_activation_request_duration_seconds_bucket[5m]))
+
+# Average request duration (works with all METRICS_DURATION_LABELS levels)
+rate(pykms_activation_request_duration_seconds_sum[5m]) / rate(pykms_activation_request_duration_seconds_count[5m])
+
+# P95 latency by product (works with BASIC, EXTENDED, or DETAILED)
+histogram_quantile(0.95, sum by (product, le) (rate(pykms_activation_request_duration_seconds_bucket[5m])))
+
+# P95 latency by KMS version (requires METRICS_DURATION_LABELS=EXTENDED or DETAILED)
+histogram_quantile(0.95, sum by (kms_version, le) (rate(pykms_activation_request_duration_seconds_bucket[5m])))
+
+# P95 latency by SKU category (requires METRICS_DURATION_LABELS=DETAILED)
+histogram_quantile(0.95, sum by (sku, le) (rate(pykms_activation_request_duration_seconds_bucket[5m])))
+```
+
+### Low-Traffic Environment Monitoring
+
+```promql
+# Total activations in the last 30 seconds (useful when connections are short-lived)
+sum(pykms_activations_last_30s)
+
+# Successful Windows activations in the last minute
+pykms_activations_last_60s{status="success", product="windows"}
+
+# Failed activations in the last 5 minutes
+sum by (product) (pykms_activations_last_300s{status="failure"})
+
+# Total activation activity in the last 5 minutes (all products)
+sum(pykms_activations_last_300s)
+
+# Success rate in the last minute (percentage)
+100 * sum(pykms_activations_last_60s{status="success"}) / sum(pykms_activations_last_60s)
+
+# Windows vs Office activations in the last 5 minutes
+sum by (product) (pykms_activations_last_300s{status="success"})
+```
+
+## See Also
+
+- [Prometheus Documentation](https://prometheus.io/docs/)
+- [Grafana Documentation](https://grafana.com/docs/)
+- [prometheus_client](https://github.com/prometheus/client_python)

--- a/examples/grafana-dashboard.json
+++ b/examples/grafana-dashboard.json
@@ -1,0 +1,1631 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 90134,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "(time() - pykms_start_time_seconds{job=\"kms_job\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic-by-name"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "dark-red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "dark-green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red"
+              },
+              {
+                "color": "dark-green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 16,
+        "x": 4,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "alignValue": "center",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "pykms_up{job=\"kms_job\"}",
+          "format": "table",
+          "instant": false,
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "KMS State Timeline",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Time",
+                "version",
+                "Value"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 0,
+        "y": 4
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "same_as_value",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": true,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "pykms_database_size_bytes{job=\"kms_job\"}",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "KMS Database Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "dtdhms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 2,
+        "y": 4
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^StartTime$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "pykms_start_time_seconds{job=\"kms_job\"} * 1000",
+          "instant": false,
+          "legendFormat": "StartTime",
+          "range": true,
+          "refId": "StartTimeSeconds"
+        }
+      ],
+      "title": "KMS Start Time",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "Value"
+              }
+            ],
+            "fields": {}
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 5,
+        "y": 4
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "pykms_info{job=\"kms_job\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "KMS Python Version",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "python_version"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 9,
+        "y": 4
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "pykms_database_last_activation_by_application{job=\"kms_job\"} * 1000",
+          "instant": false,
+          "legendFormat": "{{application}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Last Activation Time by Product",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "Value"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "office",
+                "windows"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": -1,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 32,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 5,
+        "x": 13,
+        "y": 4
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "sum(pykms_clients_total{job=\"kms_job\"}) by (application)",
+          "instant": false,
+          "legendFormat": "{{application}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unique Clients in KMS Database",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (product, le) (rate(pykms_activation_request_duration_seconds_bucket[5m])))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{product}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Latency by Product",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 5,
+        "y": 6
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": false
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "pykms_info{job=\"kms_job\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "KMS Build Tag",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "version"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 13,
+        "x": 0,
+        "y": 8
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(pykms_database_total_requests{job=\"kms_job\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Rate to KMS Database",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "pykms_activation_requests_total{job=\"kms_job\",status=\"success\"}",
+          "instant": false,
+          "legendFormat": "{{sku}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unique Success KMS Clients by SKU",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green"
+              },
+              {
+                "color": "dark-yellow",
+                "value": 5
+              },
+              {
+                "color": "dark-red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": false
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "pykms_activation_requests_total{job=\"kms_job\",status=\"failure\"}",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{sku}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unique Failure KMS Clients by SKU",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(pykms_activation_request_duration_seconds_sum{job=\"kms_job\"}) / rate(pykms_activation_request_duration_seconds_count{job=\"kms_job\"})) by (product)",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{product}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Activation Requests Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 27
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "pykms_activations_last_30s{job=\"kms_job\"}",
+          "instant": false,
+          "legendFormat": "{{product}}_{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Activations last 30s",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 27
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "pykms_activations_last_60s{job=\"kms_job\"}",
+          "instant": false,
+          "legendFormat": "{{product}}_{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Activations last 60s",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 27
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "expr": "pykms_activations_last_300s{job=\"kms_job\"}",
+          "instant": false,
+          "legendFormat": "{{product}}_{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Activations last 5m",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 5,
+      "options": {
+        "calculate": false,
+        "calculation": {
+          "xBuckets": {
+            "mode": "size",
+            "value": ""
+          },
+          "yBuckets": {
+            "mode": "size",
+            "scale": {
+              "type": "linear"
+            },
+            "value": ""
+          }
+        },
+        "cellGap": 1,
+        "cellValues": {
+          "decimals": 2,
+          "unit": "s"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "#FA6400",
+          "max": 0.8,
+          "min": 0.01,
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlGn",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (le) (rate(pykms_activation_request_duration_seconds_bucket{job=\"kms_job\",product=\"windows\"}[60m]))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Histogram Windows Activation Requests Duration by Hour",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "your_prometheus_guid"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "id": 11,
+      "options": {
+        "calculate": false,
+        "calculation": {
+          "xBuckets": {
+            "mode": "size",
+            "value": "5m"
+          },
+          "yBuckets": {
+            "mode": "size",
+            "scale": {
+              "log": 2,
+              "type": "log"
+            },
+            "value": ""
+          }
+        },
+        "cellGap": 1,
+        "cellValues": {
+          "decimals": 2,
+          "unit": "s"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "#FA6400",
+          "max": 0.8,
+          "min": 0.01,
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlGn",
+          "steps": 102
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "your_prometheus_guid"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (le) (rate(pykms_activation_request_duration_seconds_bucket{job=\"kms_job\",product=\"office\"}[60m]))",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Histogram Office Activation Requests Duration by Hour",
+      "type": "heatmap"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "LAB_KMS",
+  "uid": "da14c528-8f40-4c06-83bb-054e904389ca",
+  "version": 23
+}

--- a/py-kms/gunicorn_config.py
+++ b/py-kms/gunicorn_config.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Gunicorn configuration file for py-kms WebUI with Prometheus multiprocess support.
+"""
+
+import os
+import logging
+
+# Gunicorn logging
+accesslog = '-'
+errorlog = '-'
+loglevel = os.environ.get('LOGLEVEL', 'info').lower()
+if loglevel == 'mininfo':
+    loglevel = 'info'
+
+# Server socket
+bind = '0.0.0.0:8080'
+
+# Worker processes
+workers = 2
+worker_class = 'sync'
+worker_connections = 1000
+timeout = 30
+keepalive = 2
+
+# Server mechanics
+daemon = False
+pidfile = None
+umask = 0
+user = None
+group = None
+tmp_upload_dir = None
+
+# Worker lifecycle hooks for Prometheus multiprocess mode
+def child_exit(server, worker):
+    """
+    Called just after a worker has been exited, in the master process.
+    This is where we mark dead workers for prometheus_client.
+    """
+    try:
+        from prometheus_client import multiprocess
+        prometheus_multiproc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR', 
+                                                   os.environ.get('prometheus_multiproc_dir'))
+        if prometheus_multiproc_dir:
+            multiprocess.mark_process_dead(worker.pid)
+            logging.info(f"Marked Prometheus metrics for worker {worker.pid} as dead")
+    except Exception as e:
+        logging.warning(f"Failed to mark dead worker for Prometheus: {e}")
+
+
+def when_ready(server):
+    """
+    Called just after the server is started.
+    Clean up any stale metrics files from previous runs.
+    """
+    try:
+        from prometheus_client import multiprocess
+        prometheus_multiproc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR',
+                                                   os.environ.get('prometheus_multiproc_dir'))
+        if prometheus_multiproc_dir and os.path.exists(prometheus_multiproc_dir):
+            # Clean up any leftover .db files from previous runs
+            for filename in os.listdir(prometheus_multiproc_dir):
+                if filename.endswith('.db'):
+                    filepath = os.path.join(prometheus_multiproc_dir, filename)
+                    try:
+                        os.remove(filepath)
+                        logging.info(f"Cleaned up old Prometheus metrics file: {filename}")
+                    except Exception as e:
+                        logging.warning(f"Failed to remove {filename}: {e}")
+    except Exception as e:
+        logging.warning(f"Failed to clean up Prometheus multiprocess directory: {e}")

--- a/py-kms/pykms_Base.py
+++ b/py-kms/pykms_Base.py
@@ -11,6 +11,7 @@ from pykms_PidGenerator import epidGenerator
 from pykms_Filetimes import filetime_to_dt
 from pykms_Sql import sql_update, sql_update_epid
 from pykms_Format import justify, byterize, enco, deco, pretty_printer
+from pykms_Metrics import record_activation_request, get_product_type, get_kms_version, get_sku_label
 
 #--------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -216,6 +217,10 @@ could be detected as not genuine !{end}" %currentClientCount)
                 if self.srv_config['sqlite']:
                         sql_update(self.srv_config['sqlite'], infoDict)
 
+                # Store app and SKU names for metrics (temporary storage)
+                self.srv_config['_metrics_app_name'] = appName
+                self.srv_config['_metrics_sku_name'] = skuName
+
                 return self.createKmsResponse(kmsRequest, currentClientCount, appName)
 
         def createKmsResponse(self, kmsRequest, currentClientCount, appName):
@@ -248,20 +253,54 @@ could be detected as not genuine !{end}" %currentClientCount)
 import pykms_RequestV4, pykms_RequestV5, pykms_RequestV6, pykms_RequestUnknown
 
 def generateKmsResponseData(data, srv_config):
-        version = kmsBase.GenericRequestHeader(data)['versionMajor']
-        currentDate = time.strftime("%a %b %d %H:%M:%S %Y")
+	version = kmsBase.GenericRequestHeader(data)['versionMajor']
+	currentDate = time.strftime("%a %b %d %H:%M:%S %Y")
 
-        if version == 4:
-                loggersrv.info("Received V%d request on %s." % (version, currentDate))
-                messagehandler = pykms_RequestV4.kmsRequestV4(data, srv_config)     
-        elif version == 5:
-                loggersrv.info("Received V%d request on %s." % (version, currentDate))
-                messagehandler = pykms_RequestV5.kmsRequestV5(data, srv_config)
-        elif version == 6:
-                loggersrv.info("Received V%d request on %s." % (version, currentDate))
-                messagehandler = pykms_RequestV6.kmsRequestV6(data, srv_config)
-        else:
-                loggersrv.info("Unhandled KMS version V%d." % version)
-                messagehandler = pykms_RequestUnknown.kmsRequestUnknown(data, srv_config)
-                
-        return messagehandler.executeRequestLogic()
+	if version == 4:
+		loggersrv.info("Received V%d request on %s." % (version, currentDate))
+		messagehandler = pykms_RequestV4.kmsRequestV4(data, srv_config)	
+	elif version == 5:
+		loggersrv.info("Received V%d request on %s." % (version, currentDate))
+		messagehandler = pykms_RequestV5.kmsRequestV5(data, srv_config)
+	elif version == 6:
+		loggersrv.info("Received V%d request on %s." % (version, currentDate))
+		messagehandler = pykms_RequestV6.kmsRequestV6(data, srv_config)
+	else:
+		loggersrv.info("Unhandled KMS version V%d." % version)
+		messagehandler = pykms_RequestUnknown.kmsRequestUnknown(data, srv_config)
+	
+	# Record metrics for activation request
+	start_time = time.time()
+	kms_version = get_kms_version(version)
+	
+	try:
+		response = messagehandler.executeRequestLogic()
+		
+		# Get product and SKU from parsed data (set by serverLogic)
+		app_name = srv_config.get('_metrics_app_name', 'unknown')
+		sku_name = srv_config.get('_metrics_sku_name', 'unknown')
+		
+		# Determine product type from application name
+		product = get_product_type(app_name)
+		
+		# Get SKU label based on detail level
+		sku_label = get_sku_label(sku_name, app_name)
+		
+		# Record successful activation request metrics
+		duration = time.time() - start_time
+		record_activation_request("success", product, kms_version, duration, sku=sku_label)
+		
+		return response
+	except Exception as e:
+		# Get product and SKU from parsed data (set by serverLogic) - even on failure
+		app_name = srv_config.get('_metrics_app_name', 'unknown')
+		sku_name = srv_config.get('_metrics_sku_name', 'unknown')
+		product = get_product_type(app_name)
+		sku_label = get_sku_label(sku_name, app_name)
+		
+		# Record failed activation request metrics
+		duration = time.time() - start_time
+		record_activation_request("failure", product, kms_version, duration, sku=sku_label)
+		
+		# Re-raise the original exception
+		raise

--- a/py-kms/pykms_Metrics.py
+++ b/py-kms/pykms_Metrics.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Prometheus metrics module for py-kms server.
+
+This module defines all Prometheus metrics for monitoring KMS server activity,
+including activation requests, client statistics, and database metrics.
+"""
+
+import os
+import logging
+import time
+import shelve
+from prometheus_client import Counter, Gauge, Histogram, CollectorRegistry, generate_latest, CONTENT_TYPE_LATEST
+
+loggersrv = logging.getLogger('logsrv')
+
+# Check if metrics are enabled (default: enabled for python3 image with WebUI)
+METRICS_ENABLED = os.environ.get('METRICS', '1') == '1'
+
+# SKU detail level: NONE (default), CATEGORY, or DETAILED
+# NONE - no SKU label (default, lowest cardinality)
+# CATEGORY - SKU category (e.g., 'windows-10', 'office-2019', 'office-2021')
+# DETAILED - full SKU name (e.g., 'Windows 10 Professional', 'Office 2019 ProPlus')
+METRICS_SKU_DETAIL = os.environ.get('METRICS_SKU_DETAIL', 'NONE').upper()
+if METRICS_SKU_DETAIL not in ['NONE', 'CATEGORY', 'DETAILED']:
+    loggersrv.warning(f"Invalid METRICS_SKU_DETAIL value '{METRICS_SKU_DETAIL}'. Using 'NONE'.")
+    METRICS_SKU_DETAIL = 'NONE'
+
+# Duration labels level: BASIC (default), EXTENDED, or DETAILED
+# BASIC - product label only (default, ~51 time series: 3 products × 17 buckets)
+# EXTENDED - product + kms_version labels (~204 time series: 3 × 4 × 17)
+# DETAILED - product + kms_version + sku labels (depends on METRICS_SKU_DETAIL, high cardinality)
+METRICS_DURATION_LABELS = os.environ.get('METRICS_DURATION_LABELS', 'BASIC').upper()
+if METRICS_DURATION_LABELS not in ['BASIC', 'EXTENDED', 'DETAILED']:
+    loggersrv.warning(f"Invalid METRICS_DURATION_LABELS value '{METRICS_DURATION_LABELS}'. Using 'BASIC'.")
+    METRICS_DURATION_LABELS = 'BASIC'
+
+# Validate: DETAILED duration labels require SKU detail to be enabled
+if METRICS_DURATION_LABELS == 'DETAILED' and METRICS_SKU_DETAIL == 'NONE':
+    loggersrv.warning("METRICS_DURATION_LABELS=DETAILED requires METRICS_SKU_DETAIL to be enabled. Falling back to EXTENDED.")
+    METRICS_DURATION_LABELS = 'EXTENDED'
+
+# For multiprocess mode (Gunicorn with multiple workers)
+# In multiprocess mode, metrics are registered to the default REGISTRY and written to files
+# When collecting, we use MultiProcessCollector to aggregate from those files
+if METRICS_ENABLED:
+    try:
+        from prometheus_client import REGISTRY
+        
+        # Check if we're in multiprocess mode (Gunicorn sets this)
+        prometheus_multiproc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR', os.environ.get('prometheus_multiproc_dir'))
+        
+        if prometheus_multiproc_dir:
+            # Multiprocess mode (when running under Gunicorn)
+            # In multiprocess mode, always use the default REGISTRY
+            # The prometheus_client library will automatically handle writing to files
+            loggersrv.info(f"Prometheus metrics: multiprocess mode enabled (dir: {prometheus_multiproc_dir})")
+            registry = REGISTRY
+        else:
+            # Single process mode
+            loggersrv.debug("Prometheus metrics: single process mode")
+            registry = REGISTRY
+    except ImportError:
+        loggersrv.warning("prometheus_client module not available. Metrics will be disabled.")
+        METRICS_ENABLED = False
+        registry = None
+else:
+    loggersrv.info("Prometheus metrics disabled via METRICS environment variable.")
+    registry = None
+
+# ==============================================================================
+# Time-windowed activation tracking (for low-traffic environments)
+# ==============================================================================
+
+# Shared storage for activation events using shelve (cross-process safe)
+# Use PROMETHEUS_MULTIPROC_DIR if available, otherwise /tmp
+_events_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR', os.environ.get('prometheus_multiproc_dir', '/tmp'))
+_EVENTS_DB_PATH = os.path.join(_events_dir, 'pykms_activation_events')
+
+# Maximum time window we track (5 minutes)
+_MAX_WINDOW_SECONDS = 300
+
+loggersrv.info(f"Using activation events storage at: {_EVENTS_DB_PATH}")
+
+# ==============================================================================
+# Service Information Metrics
+# ==============================================================================
+
+if METRICS_ENABLED:
+    # For multiprocess mode, Gauge metrics need multiprocess_mode specified to avoid pid in labels
+    # 'livesum' - sum across all live workers (good for counters-as-gauges)
+    # 'liveall' - all values from all workers (creates separate series per worker)
+    # 'max' - maximum value across all workers (good for binary 0/1 values)
+    # 'min' - minimum value (good for timestamps)
+    pykms_up = Gauge('pykms_up', 'Service availability (1 = up, 0 = down)', ['version'], 
+                     registry=registry, multiprocess_mode='max')
+    pykms_start_time_seconds = Gauge('pykms_start_time_seconds', 'Unix timestamp when the service started', 
+                                      registry=registry, multiprocess_mode='min')
+    pykms_info = Gauge('pykms_info', 'Service information (always 1)', ['version', 'python_version'], 
+                       registry=registry, multiprocess_mode='max')
+
+# ==============================================================================
+# Request Metrics (from KMS Server)
+# ==============================================================================
+
+if METRICS_ENABLED:
+    # Define labels based on SKU detail level for activation counter
+    if METRICS_SKU_DETAIL == 'NONE':
+        activation_labels = ['status', 'product', 'kms_version']
+    else:
+        activation_labels = ['status', 'product', 'kms_version', 'sku']
+    
+    # Define labels for duration histogram based on METRICS_DURATION_LABELS
+    if METRICS_DURATION_LABELS == 'BASIC':
+        duration_labels = ['product']
+    elif METRICS_DURATION_LABELS == 'EXTENDED':
+        duration_labels = ['product', 'kms_version']
+    elif METRICS_DURATION_LABELS == 'DETAILED':
+        duration_labels = ['product', 'kms_version', 'sku']
+    else:
+        duration_labels = ['product']  # Fallback to BASIC
+    
+    pykms_activation_requests_total = Counter(
+        'pykms_activation_requests_total', 'Total number of KMS activation requests',
+        activation_labels, registry=registry
+    )
+    
+    loggersrv.info(f"Creating duration histogram with labels: {duration_labels}")
+    pykms_activation_request_duration_seconds = Histogram(
+        'pykms_activation_request_duration_seconds', 'Time spent processing activation requests',
+        labelnames=duration_labels,
+        buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0),
+        registry=registry
+    )
+    pykms_active_connections = Gauge('pykms_active_connections', 'Current number of active TCP connections to KMS server', 
+                                      registry=registry, multiprocess_mode='livesum')
+    
+    # Time-windowed activation metrics (for low-traffic environments)
+    # These show activation counts over recent time windows, useful when connections are very short-lived
+    # Using multiprocess_mode='max' because all workers read the same shelve data
+    pykms_activations_last_30s = Gauge(
+        'pykms_activations_last_30s', 'Number of activation requests in the last 30 seconds',
+        ['status', 'product'], registry=registry, multiprocess_mode='max'
+    )
+    pykms_activations_last_60s = Gauge(
+        'pykms_activations_last_60s', 'Number of activation requests in the last 60 seconds',
+        ['status', 'product'], registry=registry, multiprocess_mode='max'
+    )
+    pykms_activations_last_300s = Gauge(
+        'pykms_activations_last_300s', 'Number of activation requests in the last 300 seconds (5 minutes)',
+        ['status', 'product'], registry=registry, multiprocess_mode='max'
+    )
+
+# ==============================================================================
+# Client Metrics (from SQLite database)
+# ==============================================================================
+
+if METRICS_ENABLED:
+    # Database metrics read the same data from all workers, use 'max' to avoid duplication
+    pykms_clients_total = Gauge('pykms_clients_total', 'Total number of unique clients in database', ['application'], 
+                                 registry=registry, multiprocess_mode='max')
+    pykms_database_last_activation_by_application = Gauge(
+        'pykms_database_last_activation_by_application', 'Unix timestamp of most recent activation by application type',
+        ['application'], registry=registry, multiprocess_mode='max'
+    )
+
+# ==============================================================================
+# Database Metrics
+# ==============================================================================
+
+if METRICS_ENABLED:
+    # Database metrics: all workers read the same DB, use 'max' to avoid duplication
+    pykms_database_size_bytes = Gauge('pykms_database_size_bytes', 'Size of SQLite database file in bytes', 
+                                       registry=registry, multiprocess_mode='max')
+    pykms_database_last_activation_timestamp = Gauge(
+        'pykms_database_last_activation_timestamp', 'Unix timestamp of most recent activation in database', 
+        registry=registry, multiprocess_mode='max'
+    )
+    pykms_database_total_requests = Gauge(
+        'pykms_database_total_requests', 'Sum of all request counts from all clients in database', 
+        registry=registry, multiprocess_mode='max'
+    )
+
+
+# ==============================================================================
+# Helper Functions
+# ==============================================================================
+
+def get_product_type(app_name):
+    """Determine product type from application name."""
+    if not app_name:
+        return "unknown"
+    app_name_lower = str(app_name).lower()
+    if "windows" in app_name_lower:
+        return "windows"
+    elif "office" in app_name_lower:
+        return "office"
+    else:
+        return "unknown"
+
+def get_kms_version(version_major):
+    """Get KMS protocol version string from version major number."""
+    if version_major in [4, 5, 6]:
+        return f"v{version_major}"
+    else:
+        return "unknown"
+
+def get_sku_category(sku_name):
+    """
+    Extract SKU category from full SKU name.
+    
+    Examples:
+    - 'Windows 10 Professional' -> 'windows-10'
+    - 'Office 2019 ProPlus' -> 'office-2019'
+    - 'Windows Server 2016 Datacenter' -> 'windows-server-2016'
+    """
+    if not sku_name:
+        return "unknown"
+    
+    sku_lower = str(sku_name).lower()
+    
+    # Windows patterns
+    if 'windows' in sku_lower:
+        if 'server' in sku_lower:
+            # Extract Windows Server version
+            for year in ['2025', '2022', '2019', '2016', '2012']:
+                if year in sku_lower:
+                    return f"windows-server-{year}"
+            return "windows-server"
+        else:
+            # Extract Windows client version
+            if 'windows 11' in sku_lower or 'windows11' in sku_lower:
+                return "windows-11"
+            elif 'windows 10' in sku_lower or 'windows10' in sku_lower:
+                return "windows-10"
+            elif 'windows 8' in sku_lower or 'windows8' in sku_lower:
+                return "windows-8"
+            elif 'windows 7' in sku_lower or 'windows7' in sku_lower:
+                return "windows-7"
+            return "windows"
+    
+    # Office patterns
+    elif 'office' in sku_lower:
+        for year in ['2024', '2021', '2019', '2016', '2013']:
+            if year in sku_lower:
+                return f"office-{year}"
+        return "office"
+    
+    return "unknown"
+
+def get_sku_label(sku_name, app_name):
+    """
+    Get SKU label based on METRICS_SKU_DETAIL level.
+    
+    Args:
+        sku_name: SKU name (e.g., 'Windows 10 Professional')
+        app_name: Application name (for fallback)
+    
+    Returns:
+        SKU label string based on detail level, or None if SKU detail is disabled
+    """
+    if METRICS_SKU_DETAIL == 'NONE':
+        return None
+    elif METRICS_SKU_DETAIL == 'CATEGORY':
+        return get_sku_category(sku_name if sku_name else app_name)
+    elif METRICS_SKU_DETAIL == 'DETAILED':
+        # Return full SKU name, sanitized for Prometheus labels
+        if sku_name and str(sku_name).strip():
+            # Replace problematic characters for Prometheus labels
+            sanitized = str(sku_name).replace('"', '').replace("'", "").replace('\\', '')
+            return sanitized if sanitized != 'None' else 'unknown'
+        return 'unknown'
+    return None
+
+def _update_windowed_metrics():
+    """
+    Update time-windowed activation metrics by reading from shelve storage.
+    Cleans up events older than _MAX_WINDOW_SECONDS.
+    This function is called when metrics are collected (/metrics endpoint).
+    """
+    if not METRICS_ENABLED:
+        return
+    
+    current_time = time.time()
+    
+    try:
+        # Open shelve database
+        with shelve.open(_EVENTS_DB_PATH) as db:
+            # Get events list, default to empty if not exists
+            events = db.get('events', [])
+            
+            loggersrv.debug(f"Updating windowed metrics: shelve has {len(events)} events")
+            
+            # Remove events older than the maximum window
+            events = [(t, s, p) for t, s, p in events if t > current_time - _MAX_WINDOW_SECONDS]
+            
+            loggersrv.debug(f"After cleanup: {len(events)} events remain")
+            
+            # Save cleaned events back
+            db['events'] = events
+            
+            # Count events for each time window
+            counts_30s = {}
+            counts_60s = {}
+            counts_300s = {}
+            
+            cutoff_30s = current_time - 30
+            cutoff_60s = current_time - 60
+            cutoff_300s = current_time - 300
+            
+            for timestamp, status, product in events:
+                key = (status, product)
+                
+                if timestamp >= cutoff_30s:
+                    counts_30s[key] = counts_30s.get(key, 0) + 1
+                if timestamp >= cutoff_60s:
+                    counts_60s[key] = counts_60s.get(key, 0) + 1
+                if timestamp >= cutoff_300s:
+                    counts_300s[key] = counts_300s.get(key, 0) + 1
+            
+            loggersrv.info(f"Windowed counts - 30s: {counts_30s}, 60s: {counts_60s}, 300s: {counts_300s}")
+            
+            # Update metrics with absolute values
+            # Using multiprocess_mode='max', all workers read same shelve, one value wins
+            for status in ['success', 'failure']:
+                for product in ['windows', 'office', 'unknown']:
+                    key = (status, product)
+                    
+                    count_30s = counts_30s.get(key, 0)
+                    count_60s = counts_60s.get(key, 0)
+                    count_300s = counts_300s.get(key, 0)
+                    
+                    if count_30s > 0 or count_60s > 0 or count_300s > 0:
+                        loggersrv.info(f"Setting metrics for {status}/{product}: 30s={count_30s}, 60s={count_60s}, 300s={count_300s}")
+                    
+                    pykms_activations_last_30s.labels(status=status, product=product).set(count_30s)
+                    pykms_activations_last_60s.labels(status=status, product=product).set(count_60s)
+                    pykms_activations_last_300s.labels(status=status, product=product).set(count_300s)
+                    
+    except Exception as e:
+        loggersrv.error(f"Failed to update windowed metrics from shelve: {e}", exc_info=True)
+
+def record_activation_request(status, product, kms_version, duration=None, sku=None):
+    """
+    Record an activation request with metrics.
+    
+    Args:
+        status: 'success' or 'failure'
+        product: Product type ('windows', 'office', 'unknown')
+        kms_version: KMS version ('v4', 'v5', 'v6', 'unknown')
+        duration: Request duration in seconds (optional)
+        sku: SKU label (optional, used only if METRICS_SKU_DETAIL/METRICS_DURATION_LABELS require it)
+    """
+    if not METRICS_ENABLED:
+        loggersrv.debug("Metrics disabled, skipping record_activation_request")
+        return
+    
+    loggersrv.info(f"Recording activation metric: status={status}, product={product}, kms_version={kms_version}, sku={sku}, duration={duration}")
+    
+    try:
+        # Record activation counter (uses METRICS_SKU_DETAIL)
+        if METRICS_SKU_DETAIL == 'NONE':
+            loggersrv.debug(f"Recording activation counter without SKU: status={status}, product={product}, kms_version={kms_version}")
+            pykms_activation_requests_total.labels(status=status, product=product, kms_version=kms_version).inc()
+        else:
+            sku_label = sku if sku else 'unknown'
+            loggersrv.debug(f"Recording activation counter with SKU: status={status}, product={product}, kms_version={kms_version}, sku={sku_label}")
+            pykms_activation_requests_total.labels(status=status, product=product, kms_version=kms_version, sku=sku_label).inc()
+        
+        # Record duration histogram (uses METRICS_DURATION_LABELS)
+        if duration is not None:
+            if METRICS_DURATION_LABELS == 'BASIC':
+                loggersrv.debug(f"Recording duration with BASIC labels: product={product}, duration={duration}s")
+                pykms_activation_request_duration_seconds.labels(product=product).observe(duration)
+            elif METRICS_DURATION_LABELS == 'EXTENDED':
+                loggersrv.debug(f"Recording duration with EXTENDED labels: product={product}, kms_version={kms_version}, duration={duration}s")
+                pykms_activation_request_duration_seconds.labels(product=product, kms_version=kms_version).observe(duration)
+            elif METRICS_DURATION_LABELS == 'DETAILED':
+                sku_label = sku if sku else 'unknown'
+                loggersrv.debug(f"Recording duration with DETAILED labels: product={product}, kms_version={kms_version}, sku={sku_label}, duration={duration}s")
+                pykms_activation_request_duration_seconds.labels(product=product, kms_version=kms_version, sku=sku_label).observe(duration)
+        
+        # Add event to shared shelve storage (for time-based metrics)
+        try:
+            with shelve.open(_EVENTS_DB_PATH) as db:
+                events = db.get('events', [])
+                events.append((time.time(), status, product))
+                db['events'] = events
+                loggersrv.debug(f"Added activation event to shelve, total events: {len(events)}")
+        except Exception as e:
+            loggersrv.error(f"Failed to save activation event to shelve: {e}")
+        
+        loggersrv.info(f"Successfully recorded activation metric")
+    except Exception as e:
+        loggersrv.error(f"Failed to record activation request metrics: {e}", exc_info=True)
+
+def increment_active_connections():
+    """Increment active connections counter."""
+    if not METRICS_ENABLED:
+        return
+    try:
+        pykms_active_connections.inc()
+    except Exception as e:
+        loggersrv.warning(f"Failed to increment active connections: {e}")
+
+def decrement_active_connections():
+    """Decrement active connections counter."""
+    if not METRICS_ENABLED:
+        return
+    try:
+        pykms_active_connections.dec()
+    except Exception as e:
+        loggersrv.warning(f"Failed to decrement active connections: {e}")
+
+def update_database_metrics(db_path, clients):
+    """Update database-related metrics."""
+    if not METRICS_ENABLED:
+        return
+    try:
+        if os.path.exists(db_path):
+            db_size = os.path.getsize(db_path)
+            pykms_database_size_bytes.set(db_size)
+        
+        if clients:
+            windows_count = 0
+            office_count = 0
+            total_requests = 0
+            last_activation = 0
+            last_activation_windows = 0
+            last_activation_office = 0
+            
+            for client in clients:
+                app_type = get_product_type(client.get('applicationId', ''))
+                if app_type == 'windows':
+                    windows_count += 1
+                elif app_type == 'office':
+                    office_count += 1
+                
+                request_count = client.get('requestCount', 0)
+                if request_count:
+                    total_requests += request_count
+                
+                last_request_time = client.get('lastRequestTime')
+                if last_request_time:
+                    if isinstance(last_request_time, str):
+                        from datetime import datetime
+                        try:
+                            dt = datetime.fromisoformat(last_request_time)
+                            last_request_timestamp = int(dt.timestamp())
+                        except:
+                            last_request_timestamp = 0
+                    else:
+                        last_request_timestamp = int(last_request_time)
+                    
+                    if last_request_timestamp > last_activation:
+                        last_activation = last_request_timestamp
+                    
+                    # Track last activation by application type (no client_id to avoid high cardinality)
+                    if app_type == 'windows' and last_request_timestamp > last_activation_windows:
+                        last_activation_windows = last_request_timestamp
+                    elif app_type == 'office' and last_request_timestamp > last_activation_office:
+                        last_activation_office = last_request_timestamp
+            
+            pykms_clients_total.labels(application='windows').set(windows_count)
+            pykms_clients_total.labels(application='office').set(office_count)
+            pykms_database_total_requests.set(total_requests)
+            
+            if last_activation > 0:
+                pykms_database_last_activation_timestamp.set(last_activation)
+            
+            # Set last activation by application type
+            if last_activation_windows > 0:
+                pykms_database_last_activation_by_application.labels(application='windows').set(last_activation_windows)
+            if last_activation_office > 0:
+                pykms_database_last_activation_by_application.labels(application='office').set(last_activation_office)
+    except Exception as e:
+        loggersrv.warning(f"Failed to update database metrics: {e}")
+
+def initialize_metrics(version_string, python_version):
+    """Initialize service metrics."""
+    if not METRICS_ENABLED:
+        return
+    try:
+        pykms_up.labels(version=version_string).set(1)
+        pykms_start_time_seconds.set(time.time())
+        pykms_info.labels(version=version_string, python_version=python_version).set(1)
+        loggersrv.info("Prometheus metrics initialized successfully")
+    except Exception as e:
+        loggersrv.warning(f"Failed to initialize metrics: {e}")
+
+def get_metrics_output():
+    """Generate Prometheus metrics output."""
+    if not METRICS_ENABLED or registry is None:
+        return ("text/plain", b"Metrics disabled")
+    try:
+        # Update windowed metrics before generating output
+        _update_windowed_metrics()
+        
+        prometheus_multiproc_dir = os.environ.get('PROMETHEUS_MULTIPROC_DIR', os.environ.get('prometheus_multiproc_dir'))
+        if prometheus_multiproc_dir:
+            from prometheus_client import multiprocess, CollectorRegistry
+            local_registry = CollectorRegistry()
+            multiprocess.MultiProcessCollector(local_registry)
+            metrics = generate_latest(local_registry)
+        else:
+            metrics = generate_latest(registry)
+        return (CONTENT_TYPE_LATEST, metrics)
+    except Exception as e:
+        loggersrv.error(f"Failed to generate metrics: {e}")
+        return ("text/plain", f"Error generating metrics: {e}".encode('utf-8'))
+
+# Initialize all windowed metrics to 0
+if METRICS_ENABLED:
+    pykms_active_connections.set(0)
+    
+    # Initialize windowed metrics with all label combinations set to 0
+    for status in ['success', 'failure']:
+        for product in ['windows', 'office', 'unknown']:
+            pykms_activations_last_30s.labels(status=status, product=product).set(0)
+            pykms_activations_last_60s.labels(status=status, product=product).set(0)
+            pykms_activations_last_300s.labels(status=status, product=product).set(0)
+    
+    loggersrv.info("Initialized windowed activation metrics with zero values")
+

--- a/py-kms/pykms_WebUI.py
+++ b/py-kms/pykms_WebUI.py
@@ -1,5 +1,5 @@
-import os, uuid, datetime
-from flask import Flask, render_template
+import os, uuid, datetime, sys
+from flask import Flask, render_template, Response
 from pykms_Sql import sql_get_all
 from pykms_DB2Dict import kmsDB2Dict
 
@@ -57,6 +57,21 @@ if os.path.exists(_version_info_path):
             'hash': f.readline().strip(),
             'reference': f.readline().strip()
         }
+
+# Initialize Prometheus metrics
+try:
+    import pykms_Metrics
+    if pykms_Metrics.METRICS_ENABLED:
+        version_str = 'unknown'
+        if app.jinja_env.globals['version_info']:
+            version_str = app.jinja_env.globals['version_info'].get('reference', 'unknown')
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        pykms_Metrics.initialize_metrics(version_str, python_version)
+except ImportError:
+    pass  # Metrics module not available
+except Exception as e:
+    import logging
+    logging.getLogger('pykms_webui').warning(f"Failed to initialize metrics: {e}")
 
 _dbEnvVarName = 'PYKMS_SQLITE_DB_PATH'
 def _env_check():
@@ -139,4 +154,30 @@ def products():
         count_products_windows=countProductsWindows,
         count_products_office=countProductsOffice
     )
+
+@app.route('/metrics')
+def metrics():
+    """Prometheus metrics endpoint."""
+    try:
+        import pykms_Metrics
+        if not pykms_Metrics.METRICS_ENABLED:
+            return 'Metrics disabled', 503
+        
+        # Update database metrics
+        dbPath = os.environ.get(_dbEnvVarName)
+        if dbPath:
+            try:
+                clients = sql_get_all(dbPath)
+                pykms_Metrics.update_database_metrics(dbPath, clients)
+            except Exception as e:
+                pass  # Ignore errors when updating database metrics
+        
+        # Generate and return metrics
+        content_type, metrics_data = pykms_Metrics.get_metrics_output()
+        return Response(metrics_data, mimetype=content_type)
+    except ImportError:
+        return 'Metrics module not available', 503
+    except Exception as e:
+        return f'Error generating metrics: {e}', 500
+
     


### PR DESCRIPTION
This PR provides a solution to #152
It is a tested and working as expected code though written with AI support.
Based on the changes provided in this PR, I was able to build custom Docker image that exposes Prometheus metrics as proposed. After that I managed to create Grafana Dashboard for monitoring py-kms container metrics, and it looks solid (after 26 iterations of building image while working on this solution using AI and my humble programming skills).

The last image build from PR code is available here if somebody wants to test it:
https://hub.docker.com/repository/docker/ahpooch/py-kms/tags/prometheus-metrics26/sha256-f0b8449bdab21fb6491b5e5f3d0b209d96f9e09ba1b7bcb9004476b64193e259

Or you could build the Docker image yourself from the code of this PR after reading the changes it proproses to project.